### PR TITLE
Firefoxへの対応

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,10 +18,6 @@
       "512": "icons/512.png"
     }
   },
-  "oauth2": {
-    "client_id": "replace by webpack",
-    "scopes": ["replace by webpack"]
-  },
   "content_scripts": [
     {
       "matches": ["https://manaba.tsukuba.ac.jp/ct/*"],
@@ -43,5 +39,11 @@
     "64": "icons/64.png",
     "128": "icons/128.png",
     "512": "icons/512.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{2a8e688d-183a-458a-9205-062131c71228}",
+      "strict_min_version": "42.0"
+    }
   }
 }

--- a/src/repositories/trello.ts
+++ b/src/repositories/trello.ts
@@ -18,11 +18,12 @@ export class Trello extends Repository {
       return
     }
     return new Promise<void>((resolve, reject) => {
+
       chrome.identity.launchWebAuthFlow(
         {
           url:
             'https://trello.com/1/OAuthAuthorizeToken?expiration=never' +
-            `&name=${config.trello.app_name}&scope=${config.trello.scopes}&key=${config.trello.key}&return_url=https://${chrome.runtime.id}.chromiumapp.org/`,
+            `&name=${config.trello.app_name}&scope=${config.trello.scopes}&key=${config.trello.key}&return_url=${chrome.identity.getRedirectURL()}`,
           interactive: true,
         },
         async (responseUrl) => {

--- a/webpack.config.firefox.ts
+++ b/webpack.config.firefox.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { ConfigurationFactory } from 'webpack'
+import path from 'path'
+import CopyWebpackPlugin from 'copy-webpack-plugin'
+import config from './src/config/config.json'
+
+const webpackConfig: ConfigurationFactory = () => {
+  return {
+    entry: {
+      popup: path.join(__dirname, 'src', 'popup', 'main.tsx'),
+      manaba_main: path.join(
+        __dirname,
+        'src',
+        'content-scripts',
+        'manabaMain.ts'
+      ),
+      manaba_main_ui: path.join(
+        __dirname,
+        'src',
+        'content-scripts',
+        'manabaMainUI.tsx'
+      ),
+      manaba_commit: path.join(
+        __dirname,
+        'src',
+        'content-scripts',
+        'manabaCommit.tsx'
+      ),
+      background: path.join(__dirname, 'src', 'background', 'background.ts'),
+    },
+    output: {
+      path: path.join(__dirname, 'dist'),
+      filename: '[name].js',
+    },
+    module: {
+      rules: [
+        {
+          test: /.tsx?$/,
+          use: 'ts-loader',
+          exclude: '/node_modules/',
+        },
+        {
+          test: /\.css$/,
+          use: [
+            {
+              loader: 'style-loader',
+            },
+            {
+              loader: 'css-loader',
+            },
+          ],
+        },
+      ],
+    },
+    resolve: {
+      extensions: ['.ts', '.tsx', '.js', '.json'],
+    },
+    plugins: [
+      new CopyWebpackPlugin([
+        {
+          from: 'public/manifest.json',
+          to: './manifest.json',
+          transform(content): string {
+            const json = JSON.parse(content.toString())
+            json.key = config.key
+	          json.permissions = json.permissions.filter((key: string) => {
+		          return key != "declarativeContent"
+	          })
+            json.browser_action = json.page_action
+            delete json.page_action
+	          json.background.persistent = true
+            return JSON.stringify(json)
+          },
+        },
+        { from: 'public', to: '.' },
+      ]),
+    ],
+  }
+}
+
+export default webpackConfig

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -79,6 +79,8 @@ const webpackConfig: ConfigurationFactory = () => {
 	    json.permissions = json.permissions.filter((key: string) => {
 		    return key != "declarativeContent"
 	    })
+      json.browser_action = json.page_action
+      delete json.page_action
 	    json.background.persistent = true
             return JSON.stringify(json)
           },

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -68,6 +68,21 @@ const webpackConfig: ConfigurationFactory = () => {
             return JSON.stringify(json)
           },
         },
+        {
+          from: 'public/manifest.json',
+          to: './manifest_firefox.json',
+          transform(content): string {
+            const json = JSON.parse(content.toString())
+            json.oauth2.client_id = config.google.client_id
+            json.oauth2.scopes = config.google.scopes
+            json.key = config.key
+	    json.permissions = json.permissions.filter((key: string) => {
+		    return key != "declarativeContent"
+	    })
+	    json.background.persistent = true
+            return JSON.stringify(json)
+          },
+        },
         { from: 'public', to: '.' },
       ]),
     ],


### PR DESCRIPTION
# 修正内容　

- Firefoxが読み込めるようにmanifest_firefox.jsonを`dist/`に吐くようにしました。
  `manifest_firefox.json`を`manifest.json`にリネームした状態でFirefoxから有効な拡張機能とみなされます。

# テスト
- 拡張機能が有効な形式としてFirefoxに読み込まれるところまで確認しました。
- 私の方で有効なTrello/GoogleのAPIキーを持っていないため、動作テストまでは行えませんでした。

# その他
This closes #16 