### PR TITLE
フィルタ設定への説明とガイドを追加

### DIFF
--- a/src/config/const.ts
+++ b/src/config/const.ts
@@ -1,0 +1,2 @@
+export const MANABA_COURSES_LIST_URL =
+  'https://manaba.tsukuba.ac.jp/ct/home_course?chglistformat=list'

--- a/src/popup/settingSection.tsx
+++ b/src/popup/settingSection.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { readStorage, writeStorage } from '../background/utils'
 import { FormControlLabel, Switch, Paper, Button } from '@material-ui/core'
 import WhiteButton from './whiteButton'
+import { MANABA_COURSES_LIST_URL } from '../config/const'
 
 const Root = styled(Paper)({
   padding: '1rem',
@@ -35,6 +36,7 @@ const SettingSection: React.FC = () => {
           フィルタの設定
         </WhiteButton>
         <p>授業ごとや、カテゴリごとに同期するものを選択できます</p>
+        <p>この機能はManabaのコース一覧ページでのみ使用できます</p>
       </section>
       <FormControlLabel
         control={

--- a/src/popup/settingSection.tsx
+++ b/src/popup/settingSection.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { readStorage, writeStorage } from '../background/utils'
 import { FormControlLabel, Switch, Paper, Button } from '@material-ui/core'
 import WhiteButton from './whiteButton'
-import { MANABA_COURSES_LIST_URL } from '../config/const'
 
 const Root = styled(Paper)({
   padding: '1rem',


### PR DESCRIPTION
## 背景

Resovles https://github.com/twin-te/manaba-report-integration/issues/43

上記 Issue にあるようにフィルタ設定にバグはなかったが、フィルタ設定は特定の画面ではないと発動しなかったため、バグのように思えてわかりにくかった。

## 変更

- フィルタ設定についての説明を追加
- フィルタ設定画面が有効な画面以外は、有効になるコース一覧画面へ誘導するメッセージを表示するように

フィルタ設定ができない画面でメッセージが表示されても
![image](https://user-images.githubusercontent.com/45098934/205480537-ad337a6f-15e3-4744-bdcf-1f27f544a599.png)

フィルタ設定ができる画面への誘導が促され
![image](https://user-images.githubusercontent.com/45098934/205480542-b348f279-5508-4f61-9ab3-210cb5105600.png)

該当ページでもう一度「設定」を押すと
![image](https://user-images.githubusercontent.com/45098934/205480551-2181c928-2766-4b76-970b-5593e9042fb2.png)

無事フィルタ設定が編集できる
![image](https://user-images.githubusercontent.com/45098934/205480556-680c4a18-736e-4134-9ceb-e8d55a2552dd.png)


