### PR TITLE
actionlint: No-filter on master branch

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,3 +17,4 @@ jobs:
         uses: reviewdog/action-actionlint@v1
         with:
           fail_on_error: true
+          filter_mode: ${{ (github.ref_name == 'master' && 'nofilter') || 'added' }}


### PR DESCRIPTION
- #42 で言及された、reviewdog の CI が上手く動いていない問題を解消します。