### PR TITLE
eslint: No-filter on master branch

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           fail_on_error: true
           eslint_flags: '. --ext .tsx,.ts'
+          filter_mode: ${{ (github.ref_name == 'master' && 'nofilter') || 'added' }}


### PR DESCRIPTION
- #42 で言及された、reviewdog の CI が上手く動いていない問題を解消します。