### PR TITLE
trelloのhost permissionを削除

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,8 +8,7 @@
     "activeTab",
     "storage",
     "declarativeContent",
-    "https://github.com/",
-    "https://trello.com/"
+    "https://github.com/"
   ],
   "background": {
     "scripts": ["background.js"],


### PR DESCRIPTION
`trello.com/*` の権限が不必要なため削除しました。
また、権限がなくても正常に同期できることを手元で確認しました。