### PR TITLE
support manifest v3

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,15 +3,8 @@
   "version": "1.2.1",
   "manifest_version": 3,
   "description": "Manabaのレポート提出状況を外部サービスに同期します",
-  "permissions": [
-    "identity",
-    "activeTab",
-    "storage",
-    "declarativeContent"
-  ],
-  "host_permissions": [
-    "https://github.com/"
-  ],
+  "permissions": ["identity", "activeTab", "storage", "declarativeContent"],
+  "host_permissions": ["https://github.com/"],
   "background": {
     "service_worker": "background.js"
   },
@@ -44,7 +37,7 @@
       "js": ["manaba_commit.js"]
     }
   ],
-  "content_security_policy":{
+  "content_security_policy": {
     "extension_pages": "script-src 'self' ; object-src 'self'"
   },
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,20 +1,21 @@
 {
   "name": "Manaba Report Integration by Twin:te",
   "version": "1.2.1",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "Manabaのレポート提出状況を外部サービスに同期します",
   "permissions": [
     "identity",
     "activeTab",
     "storage",
-    "declarativeContent",
+    "declarativeContent"
+  ],
+  "host_permissions": [
     "https://github.com/"
   ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "page_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/16.png",
@@ -43,7 +44,9 @@
       "js": ["manaba_commit.js"]
     }
   ],
-  "content_security_policy": "script-src 'self' 'unsafe-eval' ; object-src 'self'",
+  "content_security_policy":{
+    "extension_pages": "script-src 'self' ; object-src 'self'"
+  },
   "icons": {
     "16": "icons/16.png",
     "32": "icons/32.png",

--- a/src/repositories/githubProjectV2.ts
+++ b/src/repositories/githubProjectV2.ts
@@ -376,6 +376,7 @@ export class GithubProjectV2 extends Repository {
       headers: [
         ['Authorization', `Bearer ${await this.readChromeStorage('token')}`],
       ],
+      fetch: fetch,
     })
     return getSdk(client)
   }


### PR DESCRIPTION
manifest v3に移行しました。特にソースコードの修正は必要なく`manifest.json`の編集だけで済みました。
手順としては以下を参考にしたのでリンク先に目を通してもらえると嬉しいです。
https://developer.chrome.com/docs/extensions/mv3/mv3-migration/
trelloで動作確認済みです。

## 編集点
- `manifest.json`: v3の記法に合わせた

## 確認したほうがいい点
- cspに`unsafe-eval`が指定されていたが、V3からは使えなくなったため削除しました。webpackのデバッグ用（`devtool: "eval-source-map"`）でしょうか? 特にevalを使っている部分がないので問題ないと思いますが思い当たる点があれば教えてください。
- Manifest V3からさまざまなメソッドにPromiseが実装されたので、callbackからリファクタリングすると綺麗になるかもしれません。今回は何もしていません。

close #31 