### PR TITLE
他ブラウザへの対応1

### DIFF
--- a/src/repositories/trello.ts
+++ b/src/repositories/trello.ts
@@ -22,7 +22,11 @@ export class Trello extends Repository {
         {
           url:
             'https://trello.com/1/OAuthAuthorizeToken?expiration=never' +
-            `&name=${config.trello.app_name}&scope=${config.trello.scopes}&key=${config.trello.key}&return_url=${chrome.identity.getRedirectURL()}`,
+            `&name=${config.trello.app_name}&scope=${
+              config.trello.scopes
+            }&key=${
+              config.trello.key
+            }&return_url=${chrome.identity.getRedirectURL()}`,
           interactive: true,
         },
         async (responseUrl) => {

--- a/src/repositories/trello.ts
+++ b/src/repositories/trello.ts
@@ -22,7 +22,7 @@ export class Trello extends Repository {
         {
           url:
             'https://trello.com/1/OAuthAuthorizeToken?expiration=never' +
-            `&name=${config.trello.app_name}&scope=${config.trello.scopes}&key=${config.trello.key}&return_url=https://${chrome.runtime.id}.chromiumapp.org/`,
+            `&name=${config.trello.app_name}&scope=${config.trello.scopes}&key=${config.trello.key}&return_url=${chrome.identity.getRedirectURL()}`,
           interactive: true,
         },
         async (responseUrl) => {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -64,7 +64,9 @@ const webpackConfig: ConfigurationFactory = () => {
             const json = JSON.parse(content.toString())
             json.oauth2.client_id = config.google.client_id
             json.oauth2.scopes = config.google.scopes
-            json.key = config.key
+            if (config.key != "") {
+              json.key = config.key
+            }
             return JSON.stringify(json)
           },
         },

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -64,7 +64,7 @@ const webpackConfig: ConfigurationFactory = () => {
             const json = JSON.parse(content.toString())
             json.oauth2.client_id = config.google.client_id
             json.oauth2.scopes = config.google.scopes
-            if (config.key != "") {
+            if (config.key != '') {
               json.key = config.key
             }
             return JSON.stringify(json)


### PR DESCRIPTION
Chromium系以外のブラウザに移植する際に必要となったため、以下を実装しました。

- 固定値を埋め込んでいるリダイレクトURLを、拡張機能のAPIから取得するようにしました。 (https://developer.chrome.com/docs/extensions/reference/identity/#method-getRedirectURL)
- Google OAuth keyがmanifestが定義されてない場合はkeyなしでmanifestを作るようにしました。